### PR TITLE
feat: add abgen as an opt-in conversion platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ npx @dcl/opscli queue-ab-conversion \
   [--ab-server https://ab-admin.decentraland.org] \
   [--content-server https://peer.decentraland.org/content]
 ```
-> **Note:** WebGL has been decommissioned and is no longer a valid platform target. Valid platforms are `windows` and `mac`.
-> If no platform is specified, it runs for all platforms (`windows`, `mac`). More than one can be specified at a time.
+> **Note:** WebGL has been decommissioned and is no longer a valid platform target. Valid platforms are `windows`, `mac` and `abgen`.
+> If no platform is specified, it runs for the default platforms (`windows`, `mac`). More than one can be specified at a time.
+>
+> `abgen` is not an OS: it routes the job to the abgen generator (the Rust asset-bundle pipeline), which converts every platform it supports in a single job. It is opt-in only — never included by default — and requires the target environment's ab-admin to have the abgen queue configured.
 
 > For dev, use `--ab-server https://ab-admin.decentraland.zone`.
 

--- a/src/commands/queue-ab-conversion-about.ts
+++ b/src/commands/queue-ab-conversion-about.ts
@@ -1,7 +1,7 @@
 import { AuthLinkType } from '@dcl/schemas'
 import arg from 'arg'
 import { assert } from '../helpers/assert'
-import { productionAbAdmin, Platform, queueConversions } from '../helpers/asset-bundles'
+import { productionAbAdmin, DEFAULT_PLATFORMS, Platform, queueConversions } from '../helpers/asset-bundles'
 import { fetch } from 'undici'
 import { CliError } from '../bin'
 import { parseEntityUrn } from '../helpers/parseEntityUrn'
@@ -19,7 +19,7 @@ export default async () => {
   const aboutUrl = args['--about-url']!
   const token = args['--token']!
   const abServer = args['--ab-server'] || productionAbAdmin
-  const platforms = (args['--platform'] as Platform[]) || Object.values(Platform)
+  const platforms = (args['--platform'] as Platform[]) || DEFAULT_PLATFORMS
   const force = args['--force'] || false
 
   const shouldPrioritize = !!args['--prioritize']

--- a/src/commands/queue-ab-conversion-snapshot.ts
+++ b/src/commands/queue-ab-conversion-snapshot.ts
@@ -3,7 +3,7 @@ import arg from 'arg'
 import { fetch } from 'undici'
 import { CliError } from '../bin'
 import { assert } from '../helpers/assert'
-import { productionAbAdmin, Platform, queueConversions } from '../helpers/asset-bundles'
+import { productionAbAdmin, DEFAULT_PLATFORMS, Platform, queueConversions } from '../helpers/asset-bundles'
 import { StringDecoder } from 'string_decoder'
 import { exit } from 'process'
 
@@ -26,7 +26,7 @@ export default async () => {
   const snapshot = args['--snapshot'] || 'wearable'
   const token = args['--token']!
   const abServer = args['--ab-server'] || productionAbAdmin
-  const platforms = (args['--platform'] as Platform[]) || Object.values(Platform)
+  const platforms = (args['--platform'] as Platform[]) || DEFAULT_PLATFORMS
   const shouldPrioritize = !!args['--prioritize']
 
   assert(!!snapshot, '--snapshot is missing')

--- a/src/commands/queue-ab-conversion.ts
+++ b/src/commands/queue-ab-conversion.ts
@@ -1,7 +1,7 @@
 import { AuthLinkType, IPFSv1, IPFSv2 } from '@dcl/schemas'
 import arg from 'arg'
 import { assert } from '../helpers/assert'
-import { productionAbAdmin, Platform, queueConversions } from '../helpers/asset-bundles'
+import { productionAbAdmin, DEFAULT_PLATFORMS, Platform, queueConversions } from '../helpers/asset-bundles'
 import { getActiveEntities } from '../helpers/downloads'
 
 export default async () => {
@@ -22,7 +22,7 @@ export default async () => {
   const cids = args['--cid'] || []
   const token = args['--token']!
   const abServer = args['--ab-server'] || productionAbAdmin
-  const platforms = (args['--platform'] as Platform[]) || Object.values(Platform)
+  const platforms = (args['--platform'] as Platform[]) || DEFAULT_PLATFORMS
   const contentUrl = (args['--content-server'] || 'https://peer.decentraland.org/content').replace(/\/$/, '')
   const shouldPrioritize = !!args['--prioritize']
   const animation = args['--animation'] || 'legacy'

--- a/src/helpers/asset-bundles.ts
+++ b/src/helpers/asset-bundles.ts
@@ -6,8 +6,15 @@ export const productionAbAdmin = 'https://ab-admin.decentraland.org'
 
 export enum Platform {
   WINDOWS = 'windows',
-  MAC = 'mac'
+  MAC = 'mac',
+  // Not an OS: routes the job to the abgen generator's queue instead of a Unity
+  // converter queue (one abgen job converts every platform it supports).
+  ABGEN = 'abgen'
 }
+
+// Used when --platform is omitted. abgen is deliberately excluded so default and
+// mass reconversions don't feed it until explicitly requested with --platform abgen.
+export const DEFAULT_PLATFORMS = [Platform.WINDOWS, Platform.MAC]
 
 export async function queueConversions(
   customABConverterServer: string,


### PR DESCRIPTION
## What

Adds `abgen` as a valid `--platform` value on `queue-ab-conversion`, `queue-ab-conversion-snapshot` and `queue-ab-conversion-about`, routing the job to the abgen generator (the Rust asset-bundle pipeline) through ab-admin's `/enqueue-task`.

## Details

- **Opt-in only**: the default platform set is now an explicit `DEFAULT_PLATFORMS = [windows, mac]` instead of `Object.values(Platform)`, so omitting `--platform` behaves exactly as today and mass snapshot reconversions never feed abgen implicitly.
- abgen is not an OS — one abgen job converts every platform the generator supports, so there's a single queue behind it (no priority lane; `--prioritize` is accepted but lands on the same queue).
- `--force` works: abgen honors it by bypassing its already-converted-at-AB_VERSION check. `--animation`/`--doISS` are Unity-only and ignored by abgen.

## Depends on

ab-admin support for `platform=abgen` (ops-lambdas MR 408: https://dcl.tools/ops/ops-lambdas/-/merge_requests/408), deployed with `TASK_QUEUE_ABGEN` configured in the target environment — otherwise ab-admin returns a 400 for abgen requests. Don't publish this until that MR is deployed and validated on dev (`--ab-server https://ab-admin.decentraland.zone`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)